### PR TITLE
Bug fix: added request url query string parameters into signature base.

### DIFF
--- a/src/OAuth.Net35/OAuth.Net35.csproj
+++ b/src/OAuth.Net35/OAuth.Net35.csproj
@@ -70,6 +70,9 @@
     <Compile Include="..\OAuth\WebParameterCollection.cs">
       <Link>WebParameterCollection.cs</Link>
     </Compile>
+    <Compile Include="..\OAuth\WebUtils.cs">
+      <Link>WebUtils.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OAuth.Tests/OAuth.Tests.csproj
+++ b/src/OAuth.Tests/OAuth.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="OAuthTests.cs" />
     <Compile Include="OAuthToolsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebUtilsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/OAuth.Tests/WebUtilsTest.cs
+++ b/src/OAuth.Tests/WebUtilsTest.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace OAuth.Tests
+{
+    [TestFixture]
+    public class WebUtilsTest
+    {
+        [TestCase("https://www.google.com", 0)]
+        [TestCase("https://www.google.com/", 0)]
+        [TestCase("https://www.google.com/?a=b", 1)]
+        [TestCase("https://www.google.com/?a=b&c=d", 2)]
+        [TestCase("https://www.google.com/?a=b&c=d&e=f", 3)]
+        public void ParsesQueryString(string url, int expectedQueryParametersCount)
+        {
+            Assert.AreEqual(expectedQueryParametersCount, WebUtils.ParseQueryString(new Uri(url)).Count());
+        }
+
+        [TestCase("https://www.google.com/?")]
+        [TestCase("https://www.google.com/?a=b&c=d&e=f&")]
+        public void ParseQueryStringThrowsForInvalidQueryString(string invalidUrl)
+        {
+            // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            Assert.Throws<ArgumentException>(() => WebUtils.ParseQueryString(new Uri(invalidUrl)).ToList());
+        }
+    }
+}

--- a/src/OAuth/OAuth.csproj
+++ b/src/OAuth/OAuth.csproj
@@ -57,6 +57,7 @@
     <Compile Include="WebParameter.cs" />
     <Compile Include="WebParameterCollection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="oauth.snk" />

--- a/src/OAuth/OAuthTools.cs
+++ b/src/OAuth/OAuthTools.cs
@@ -275,7 +275,9 @@ namespace OAuth
 
             // Separating &'s are not URL encoded
             var requestMethod = string.Concat(method.ToUpper(), "&");
-            var requestUrl = string.Concat(UrlEncodeRelaxed(ConstructRequestUrl(new Uri(url))), "&");
+            var uri = new Uri(url);
+            var requestUrl = string.Concat(UrlEncodeRelaxed(ConstructRequestUrl(uri)), "&");
+            parameters.AddRange(WebUtils.ParseQueryString(uri));
             var requestParameters = UrlEncodeRelaxed(NormalizeRequestParameters(parameters));
             
             sb.Append(requestMethod);

--- a/src/OAuth/WebUtils.cs
+++ b/src/OAuth/WebUtils.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OAuth
+{
+    public static class WebUtils
+    {
+        public static IEnumerable<WebParameter> ParseQueryString(Uri uri)
+        {
+            if (string.IsNullOrEmpty(uri.Query) || uri.Query[0] != '?')
+                yield break;
+            var qsParams = uri.Query.Substring(1).Split('&');
+            foreach (var param in qsParams)
+            {
+                var pair = param.Split('=');
+                if (pair.Length != 2)
+                    throw new ArgumentException("Uri does not have valid query string.");
+                yield return new WebParameter(pair[0], pair[1]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
When request URL has query string parameters, the signature base has to contains URL without query string and each parameter of query string has to be added as separate argument of signature string.